### PR TITLE
Fix theory/pg-semver#15.

### DIFF
--- a/src/semver.c
+++ b/src/semver.c
@@ -213,7 +213,7 @@ semver* parse_semver(char* str, bool lax, bool throw, bool* bad)
                 }
             }
             if ((started_prerel || started_meta) && !skip_char) {
-              pred = (i > 0 && patch[i-1] == '0' && next != '.');
+              pred = (i > 1 && patch[i-2] == '.' && patch[i-1] == '0' && next != '.');
               if (pred && !lax)   {  // Leading zeros
                     *bad = true;
                     if (throw)

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..251
+1..252
 ok 1 - Type semver should exist
 ok 2 - semvers should be NULLable
 ok 3 - "1.2.2" is a valid semver
@@ -251,3 +251,4 @@ ok 248 - is_semver(1.4b.0) should return false
 ok 249 - is_semver(1v) should return false
 ok 250 - is_semver(1v.2.2v) should return false
 ok 251 - is_semver(1.2.4b.5) should return false
+ok 252 - is_semver(2016.5.18-MYW-600) should return true

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -21,7 +21,7 @@ $$;
 
 SELECT * FROM create_unnest();
 
-SELECT plan(251);
+SELECT plan(252);
 --SELECT * FROM no_plan();
 
 SELECT has_type('semver');
@@ -334,7 +334,8 @@ SELECT is(
     ('1.4b.0',               false),
     ('1v',                   false),
     ('1v.2.2v',              false),
-    ('1.2.4b.5',             false)
+    ('1.2.4b.5',             false),
+    ('2016.5.18-MYW-600',    true)
 ) v(stimulus, expected);
 
 SELECT * FROM finish();


### PR DESCRIPTION
Logic used to detect leading zeros in pre-release/metadata values was
erroneously detecting any zeros as leading.

Ex: 2016.5.18-MYW-600 is a valid semver (after internal coercion to
the conforming value 2016.5.18-MYW.600) but we were saying it was
invalid due to the 0 in 600.