### PR TITLE
Allow dash (-) after metadata.

### DIFF
--- a/src/semver.c
+++ b/src/semver.c
@@ -1,3 +1,4 @@
+//  -*- tab-width:4; c-basic-offset:4; indent-tabs-mode:nil;  -*-
 /*
  * PostgreSQL type definitions for semver type
  * Written by Sam Vilain
@@ -156,15 +157,7 @@ semver* parse_semver(char* str, bool lax, bool throw, bool* bad)
                 ptr = endptr;
             }
         } else {  // Onto pre-release/metadata
-            if (!started_prerel && (next == '-' || (!started_meta && next != '+' && lax) )) {  // Starts with -
-                if (started_meta) {  // Pre-release flag can't come after metadata
-                    *bad = true;
-                    if (throw)
-                        elog(ERROR, "bad semver value '%s': pre-release (-) after metadata (+) at char %d", str, atchar);
-                    else
-                        break;
-                }
-
+            if (!started_prerel && !started_meta && (next == '-' || (next != '+' && lax))) {  // Starts with -
                 started_prerel = true;
                 if (next == '-') {
                     skip_char = true;
@@ -201,7 +194,7 @@ semver* parse_semver(char* str, bool lax, bool throw, bool* bad)
                     break;
             }
 
-            if (!skip_char && (next != '.' && next != '+' && !isalpha(next) && !isdigit(next))) {
+            if (!skip_char && (next != '.' && next != '+' && next != '-' && !isalpha(next) && !isdigit(next))) {
                 if (lax && isspace(next))  // In lax mode, ignore whitespace
                     skip_char = true;
                 else {

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..259
+1..260
 ok 1 - Type semver should exist
 ok 2 - semvers should be NULLable
 ok 3 - "1.2.2" is a valid semver
@@ -212,7 +212,7 @@ ok 209 - "1.0.0-0.3.7" is a valid 2.0.0 semver
 ok 210 - "1.0.0-x.7.z.92" is a valid 2.0.0 semver
 ok 211 - "1.0.0-a.." is not a valid 2.0.0 semver
 ok 212 - "1.0.0-a.1." is not a valid 2.0.0 semver
-ok 213 - "1.0.0+1-1" is not a valid 2.0.0 semver
+ok 213 - "1.0.0+1_1" is not a valid 2.0.0 semver
 ok 214 - "1.0.0-1...." is not a valid 2.0.0 semver
 ok 215 - "1.0.0-1_2" is not a valid 2.0.0 semver
 ok 216 - "1.0.0-1.02" is not a valid 2.0.0 semver
@@ -259,3 +259,4 @@ ok 256 - is_semver(1v) should return false
 ok 257 - is_semver(1v.2.2v) should return false
 ok 258 - is_semver(1.2.4b.5) should return false
 ok 259 - is_semver(2016.5.18-MYW-600) should return true
+ok 260 - is_semver(1010.5.0+2016-05-27-1832) should return true

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -9,19 +9,19 @@ CREATE FUNCTION create_unnest(
 ) RETURNS SETOF BOOLEAN LANGUAGE PLPGSQL AS $$
 BEGIN
     IF pg_version_num() < 80400 THEN
-        EXECUTE $F$ CREATE FUNCTION unnest(
-            anyarray
-        ) RETURNS SETOF anyelement LANGUAGE sql AS $_$
-            SELECT $1[i]
-              FROM generate_series(array_lower($1, 1), array_upper($1, 1)) AS i;
-        $_$;$F$;
+	EXECUTE $F$ CREATE FUNCTION unnest(
+	    anyarray
+	) RETURNS SETOF anyelement LANGUAGE sql AS $_$
+	    SELECT $1[i]
+	      FROM generate_series(array_lower($1, 1), array_upper($1, 1)) AS i;
+	$_$;$F$;
     END IF;
 END;
 $$;
 
 SELECT * FROM create_unnest();
 
-SELECT plan(259);
+SELECT plan(260);
 --SELECT * FROM no_plan();
 
 SELECT has_type('semver');
@@ -272,7 +272,7 @@ SELECT throws_ok(
 )  FROM unnest(ARRAY[
    '1.0.0-a..',
    '1.0.0-a.1.',
-   '1.0.0+1-1',
+   '1.0.0+1_1',
    '1.0.0-1....',
    '1.0.0-1_2',
    '1.0.0-1.02'
@@ -326,30 +326,31 @@ SELECT is(
     expected,
     'is_semver(' || stimulus || ') should return ' || expected::text
 ) FROM (VALUES
-    ('1.2.2',                true),
-    ('0.2.2',                true),
-    ('0.0.0',                true),
-    ('0.1.999',              true),
-    ('9999.9999999.823823',  true),
-    ('1.0.0-beta1',          true),
-    ('1.0.0-beta2',          true),
-    ('1.0.0',                true),
-    ('1.0.0-1',              true),
-    ('1.0.0-alpha+d34dm34t', true),
-    ('1.0.0+d34dm34t',       true),
-    ('20110204.0.0',         true),
-    ('1.2',                  false),
-    ('1.2.02',               false),
-    ('1.2.2-',               false),
-    ('1.2.3b#5',             false),
-    ('03.3.3',               false),
-    ('v1.2.2',               false),
-    ('1.3b',                 false),
-    ('1.4b.0',               false),
-    ('1v',                   false),
-    ('1v.2.2v',              false),
-    ('1.2.4b.5',             false),
-    ('2016.5.18-MYW-600',    true)
+    ('1.2.2',                    true),
+    ('0.2.2',                    true),
+    ('0.0.0',                    true),
+    ('0.1.999',                  true),
+    ('9999.9999999.823823',      true),
+    ('1.0.0-beta1',              true),
+    ('1.0.0-beta2',              true),
+    ('1.0.0',                    true),
+    ('1.0.0-1',                  true),
+    ('1.0.0-alpha+d34dm34t',     true),
+    ('1.0.0+d34dm34t',           true),
+    ('20110204.0.0',             true),
+    ('1.2',                      false),
+    ('1.2.02',                   false),
+    ('1.2.2-',                   false),
+    ('1.2.3b#5',                 false),
+    ('03.3.3',                   false),
+    ('v1.2.2',                   false),
+    ('1.3b',                     false),
+    ('1.4b.0',                   false),
+    ('1v',                       false),
+    ('1v.2.2v',                  false),
+    ('1.2.4b.5',                 false),
+    ('2016.5.18-MYW-600',        true),
+    ('1010.5.0+2016-05-27-1832', true)
 ) v(stimulus, expected);
 
 SELECT * FROM finish();


### PR DESCRIPTION
This adds "1010.5.0+2016-05-27-1832" and the like as valid.

According to: http://semver.org/spec/v2.0.0.html

    10. Build metadata MAY be denoted by appending a plus sign and a series
	of dot separated identifiers immediately following the patch or
	pre-release version. Identifiers MUST comprise only ASCII alphanumerics
	and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty.

Previously, we had only accepted alphanumerics after the plus sign (+).

Fixes theory/pg-semver#19