### PR TITLE
fix: as per spec get_semver_prerelease must return only prerel

### DIFF
--- a/src/semver.c
+++ b/src/semver.c
@@ -392,7 +392,7 @@ Datum
 get_semver_prerelease(PG_FUNCTION_ARGS)
 {
     semver* sv = PG_GETARG_SEMVER_P(0);
-    char* prerelease = sv->prerel;
+    char* prerelease = strip_meta(sv->prerel);
     text* res = cstring_to_text(prerelease);
     PG_RETURN_TEXT_P(res);
 }

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..294
+1..296
 ok 1 - Type semver should exist
 ok 2 - semvers should be NULLable
 ok 3 - "1.2.2" is a valid semver
@@ -288,9 +288,11 @@ ok 285 - Function get_semver_prerelease() should exist
 ok 286 - semver
 ok 287 - Function get_semver_prerelease() should return text
 ok 288 - prerelease label check
-ok 289 - 1.0.0 should be in range [1.0.0, 2.0.0]
-ok 290 - 1.0.0 should not be in range [1.0.1, 2.0.0]
-ok 291 - 2.0.0 should not be in range [1.0.1, 2.0.0)
-ok 292 - 1.9999.9999 should be in range [1.0.1, 2.0.0)
-ok 293 - 1000.0.0 should be in range [1.0.0,)
-ok 294 - Should be able to work with arrays of semverranges
+ok 289 - prerelease label check. must return prerelease only
+ok 290 - prerelease label check. must return empty string
+ok 291 - 1.0.0 should be in range [1.0.0, 2.0.0]
+ok 292 - 1.0.0 should not be in range [1.0.1, 2.0.0]
+ok 293 - 2.0.0 should not be in range [1.0.1, 2.0.0)
+ok 294 - 1.9999.9999 should be in range [1.0.1, 2.0.0)
+ok 295 - 1000.0.0 should be in range [1.0.0,)
+ok 296 - Should be able to work with arrays of semverranges

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -4,7 +4,7 @@ BEGIN;
 \i test/pgtap-core.sql
 \i sql/semver.sql
 
-SELECT plan(294);
+SELECT plan(296);
 --SELECT * FROM no_plan();
 
 SELECT has_type('semver');
@@ -414,6 +414,8 @@ SELECT has_function('get_semver_prerelease');
 SELECT has_function('get_semver_prerelease', 'semver');
 SELECT function_returns('get_semver_prerelease', 'text');
 SELECT is(get_semver_prerelease('2.1.0-alpha'::semver), 'alpha', 'prerelease label check');
+SELECT is(get_semver_prerelease('2.1.0-alpha+build'::semver), 'alpha', 'prerelease label check. must return prerelease only');
+SELECT is(get_semver_prerelease('2.1.0+build'::semver), '', 'prerelease label check. must return empty string');
 
 -- Test range type.
 SELECT ok(
@@ -429,6 +431,7 @@ SELECT ok(
     NOT semverrange('1.0.0', '2.0.0') @> '2.0.0'::semver,
     '2.0.0 should not be in range [1.0.1, 2.0.0)'
 );
+
 SELECT ok(
     semverrange('1.0.0', '2.0.0') @> '1.9999.9999'::semver,
     '1.9999.9999 should be in range [1.0.1, 2.0.0)'


### PR DESCRIPTION
In case semver has both prerel and build parts e.g 1.2.3-rc.c+kiss
get_semver_prerelease returns rc.c+kiss which makes it impossible
to make query returning last stable release.
For example. database has 2 versions
 - 1.2.2
 - 1.2.3+build
 - 1.2.4-rc.1+build

query like below returns 1.2.2 but version 1.2.3+build is expected
```SQL
SELECT * FROM versions
  WHERE get_semver_prerelease(version) = ''
  ORDER BY version DESC LIMIT 1;
```

This fix turns get_semver_prerelease function
to return prerel part only