### PR TITLE
Fix leading zeros

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,11 @@ Revision history for PostgreSQL extension semver.
         had been doing so on the assumption that dashes were invalid in SemVer
         1.0 and 2.0 prerelease parts, but that does not turn out to be the case.
         Thanks to @Nemo157 for the report (#46).
+      - Fixed the parsing of prerelease and metadata parts to allow leading
+        zeros for parts with non-numeric characters, e.g., `1.0.0-alpha.0a`, and
+        to disallow parts with leading zeros and only numeric characters, e.g.,
+        `1.0.0-02799`. Thanks to @Nemo157 for the bug report, and to Joseph
+        Donahue for the SemVer spec expertise (#45).
 
 0.22.0  2020-04-02T14:13:55Z
       - Fixed `get_semver_prerelease()` so that it returns only the

--- a/src/semver.c
+++ b/src/semver.c
@@ -207,7 +207,22 @@ semver* parse_semver(char* str, bool lax, bool throw, bool* bad)
                 }
             }
             if ((started_prerel || started_meta) && !skip_char) {
-                pred = (i > 1 && patch[i-2] == '.' && patch[i-1] == '0' && next != '.');
+                if ((i == 1 || patch[i-2] == '.') && patch[i-1] == '0' && isdigit(next)) {
+                    pred = true;
+                    // Scan ahead.
+                    for (p = len - atchar; p < len; p++) {
+                        if (str[p] == '.') {
+                            // We got to the end of this bit.
+                            break;
+                        }
+                        if (isalpha(str[p])) {
+                            // If there is a letter, it's okay to start with a leading 0.
+                            pred = false;
+                            break;
+                        }
+                    }
+                }
+
                 if (!started_meta && (pred && !lax))   {  // Leading zeros
                     *bad = true;
                     if (throw)

--- a/src/semver.c
+++ b/src/semver.c
@@ -226,7 +226,7 @@ semver* parse_semver(char* str, bool lax, bool throw, bool* bad)
                 if (!started_meta && (pred && !lax))   {  // Leading zeros
                     *bad = true;
                     if (throw)
-                        elog(ERROR, "bad semver value '%s': semver version numbers can't start with 0", str);
+                        elog(ERROR, "bad semver value '%s': semver prerelease numbers can't start with 0", str);
                     else
                         break;
                 } else if (pred && lax)  {  // Swap erroneous leading zero with whatever this is
@@ -236,6 +236,7 @@ semver* parse_semver(char* str, bool lax, bool throw, bool* bad)
                     patch[i] = next;
                     i++;
                 }
+                pred = false;
             }
             atchar++;
             ptr++;

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..303
+1..305
 ok 1 - Type semver should exist
 ok 2 - semvers should be NULLable
 ok 3 - "1.2.2" is a valid semver
@@ -15,291 +15,293 @@ ok 12 - "1.0.0-alpha+d34dm34t" is a valid semver
 ok 13 - "1.0.0+d34dm34t" is a valid semver
 ok 14 - "20110204.0.0" is a valid semver
 ok 15 - "1.0.0-alpha.0a" is a valid semver
-ok 16 - "1.0.0-0AEF" is a valid semver
-ok 17 - "1.2" is not a valid semver
-ok 18 - "1.2.02" is not a valid semver
-ok 19 - "1.2.2-" is not a valid semver
-ok 20 - "1.2.3b#5" is not a valid semver
-ok 21 - "03.3.3" is not a valid semver
-ok 22 - "v1.2.2" is not a valid semver
-ok 23 - "1.3b" is not a valid semver
-ok 24 - "1.4b.0" is not a valid semver
-ok 25 - "1v" is not a valid semver
-ok 26 - "1v.2.2v" is not a valid semver
-ok 27 - "1.2.4b.5" is not a valid semver
-ok 28 - "1.0.0-alpha.010" is not a valid semver
-ok 29 - "1.0.0-02799" is not a valid semver
-ok 30 - semver(1.2.2, 1.2.2) should = 0
-ok 31 - v1.2.2 should = v1.2.2
-ok 32 - v1.2.2 should be <= v1.2.2
-ok 33 - v1.2.2 should be >= v1.2.2
-ok 34 - semver(1.2.23, 1.2.23) should = 0
-ok 35 - v1.2.23 should = v1.2.23
-ok 36 - v1.2.23 should be <= v1.2.23
-ok 37 - v1.2.23 should be >= v1.2.23
-ok 38 - semver(0.0.0, 0.0.0) should = 0
-ok 39 - v0.0.0 should = v0.0.0
-ok 40 - v0.0.0 should be <= v0.0.0
-ok 41 - v0.0.0 should be >= v0.0.0
-ok 42 - semver(999.888.7777, 999.888.7777) should = 0
-ok 43 - v999.888.7777 should = v999.888.7777
-ok 44 - v999.888.7777 should be <= v999.888.7777
-ok 45 - v999.888.7777 should be >= v999.888.7777
-ok 46 - semver(0.1.2-beta3, 0.1.2-beta3) should = 0
-ok 47 - v0.1.2-beta3 should = v0.1.2-beta3
-ok 48 - v0.1.2-beta3 should be <= v0.1.2-beta3
-ok 49 - v0.1.2-beta3 should be >= v0.1.2-beta3
-ok 50 - semver(1.0.0-rc-1, 1.0.0-RC-1) should = 0
-ok 51 - v1.0.0-rc-1 should = v1.0.0-RC-1
-ok 52 - v1.0.0-rc-1 should be <= v1.0.0-RC-1
-ok 53 - v1.0.0-rc-1 should be >= v1.0.0-RC-1
-ok 54 - semver(1.2.2, 1.2.3) should <> 0
-ok 55 - v1.2.2 should not equal v1.2.3
-ok 56 - semver(0.0.1, 1.0.0) should <> 0
-ok 57 - v0.0.1 should not equal v1.0.0
-ok 58 - semver(1.0.1, 1.1.0) should <> 0
-ok 59 - v1.0.1 should not equal v1.1.0
-ok 60 - semver(1.1.1, 1.1.0) should <> 0
-ok 61 - v1.1.1 should not equal v1.1.0
-ok 62 - semver(1.2.3-b, 1.2.3) should <> 0
-ok 63 - v1.2.3-b should not equal v1.2.3
-ok 64 - semver(1.2.3, 1.2.3-b) should <> 0
-ok 65 - v1.2.3 should not equal v1.2.3-b
-ok 66 - semver(1.2.3-a, 1.2.3-b) should <> 0
-ok 67 - v1.2.3-a should not equal v1.2.3-b
-ok 68 - semver(1.2.3-aaaaaaa1, 1.2.3-aaaaaaa2) should <> 0
-ok 69 - v1.2.3-aaaaaaa1 should not equal v1.2.3-aaaaaaa2
-ok 70 - semver(1.2.3-1.2.3, 1.2.3-1.2.3.4) should <> 0
-ok 71 - v1.2.3-1.2.3 should not equal v1.2.3-1.2.3.4
-ok 72 - semver(2.2.2, 1.1.1) should > 0
-ok 73 - semver(1.1.1, 2.2.2) should < 0
-ok 74 - v2.2.2 should be > v1.1.1
-ok 75 - v2.2.2 should be >= v1.1.1
-ok 76 - v1.1.1 should be < v2.2.2
-ok 77 - v1.1.1 should be <= v2.2.2
-ok 78 - semver(2.2.2, 2.1.1) should > 0
-ok 79 - semver(2.1.1, 2.2.2) should < 0
-ok 80 - v2.2.2 should be > v2.1.1
-ok 81 - v2.2.2 should be >= v2.1.1
-ok 82 - v2.1.1 should be < v2.2.2
-ok 83 - v2.1.1 should be <= v2.2.2
-ok 84 - semver(2.2.2, 2.2.1) should > 0
-ok 85 - semver(2.2.1, 2.2.2) should < 0
-ok 86 - v2.2.2 should be > v2.2.1
-ok 87 - v2.2.2 should be >= v2.2.1
-ok 88 - v2.2.1 should be < v2.2.2
-ok 89 - v2.2.1 should be <= v2.2.2
-ok 90 - semver(2.2.2-b, 2.2.1) should > 0
-ok 91 - semver(2.2.1, 2.2.2-b) should < 0
-ok 92 - v2.2.2-b should be > v2.2.1
-ok 93 - v2.2.2-b should be >= v2.2.1
-ok 94 - v2.2.1 should be < v2.2.2-b
-ok 95 - v2.2.1 should be <= v2.2.2-b
-ok 96 - semver(2.2.2, 2.2.2-b) should > 0
-ok 97 - semver(2.2.2-b, 2.2.2) should < 0
-ok 98 - v2.2.2 should be > v2.2.2-b
-ok 99 - v2.2.2 should be >= v2.2.2-b
-ok 100 - v2.2.2-b should be < v2.2.2
-ok 101 - v2.2.2-b should be <= v2.2.2
-ok 102 - semver(2.2.2-c, 2.2.2-b) should > 0
-ok 103 - semver(2.2.2-b, 2.2.2-c) should < 0
-ok 104 - v2.2.2-c should be > v2.2.2-b
-ok 105 - v2.2.2-c should be >= v2.2.2-b
-ok 106 - v2.2.2-b should be < v2.2.2-c
-ok 107 - v2.2.2-b should be <= v2.2.2-c
-ok 108 - semver(2.2.2-rc-2, 2.2.2-RC-1) should > 0
-ok 109 - semver(2.2.2-RC-1, 2.2.2-rc-2) should < 0
-ok 110 - v2.2.2-rc-2 should be > v2.2.2-RC-1
-ok 111 - v2.2.2-rc-2 should be >= v2.2.2-RC-1
-ok 112 - v2.2.2-RC-1 should be < v2.2.2-rc-2
-ok 113 - v2.2.2-RC-1 should be <= v2.2.2-rc-2
-ok 114 - semver(0.9.10, 0.9.9) should > 0
-ok 115 - semver(0.9.9, 0.9.10) should < 0
-ok 116 - v0.9.10 should be > v0.9.9
-ok 117 - v0.9.10 should be >= v0.9.9
-ok 118 - v0.9.9 should be < v0.9.10
-ok 119 - v0.9.9 should be <= v0.9.10
-ok 120 - semver(1.0.1-1.2.3, 1.0.1-0.9.9.9) should > 0
-ok 121 - semver(1.0.1-0.9.9.9, 1.0.1-1.2.3) should < 0
-ok 122 - v1.0.1-1.2.3 should be > v1.0.1-0.9.9.9
-ok 123 - v1.0.1-1.2.3 should be >= v1.0.1-0.9.9.9
-ok 124 - v1.0.1-0.9.9.9 should be < v1.0.1-1.2.3
-ok 125 - v1.0.1-0.9.9.9 should be <= v1.0.1-1.2.3
-ok 126 - Function to_semver() should exist
-ok 127 - Function to_semver(text) should exist
-ok 128 - Function to_semver() should return semver
-ok 129 - to_semver(1.2.2) should return 1.2.2
-ok 130 - to_semver(01.2.2) should return 1.2.2
-ok 131 - to_semver(1.02.2) should return 1.2.2
-ok 132 - to_semver(1.2.02) should return 1.2.2
-ok 133 - to_semver(1.2.02b) should return 1.2.2-b
-ok 134 - to_semver(1.2.02beta-3  ) should return 1.2.2-beta-3
-ok 135 - to_semver(1.02.02rc1) should return 1.2.2-rc1
-ok 136 - to_semver(1.0) should return 1.0.0
-ok 137 - to_semver(1) should return 1.0.0
-ok 138 - to_semver(.0.02) should return 0.0.2
-ok 139 - to_semver(1..02) should return 1.0.2
-ok 140 - to_semver(1..) should return 1.0.0
-ok 141 - to_semver(1.1) should return 1.1.0
-ok 142 - to_semver(1.2.b1) should return 1.2.0-b1
-ok 143 - to_semver(9.0beta4) should return 9.0.0-beta4
-ok 144 - to_semver(9b) should return 9.0.0-b
-ok 145 - to_semver(rc1) should return 0.0.0-rc1
-ok 146 - to_semver() should return 0.0.0
-ok 147 - to_semver(..2) should return 0.0.2
-ok 148 - to_semver(1.2.3 a) should return 1.2.3-a
-ok 149 - to_semver(..2 b) should return 0.0.2-b
-ok 150 - to_semver(  012.2.2) should return 12.2.2
-ok 151 - to_semver(20110204) should return 20110204.0.0
-ok 152 - to_semver(1.0.0-alpha) should return incoming text
-ok 153 - to_semver(1.0.0-alpha.1) should return incoming text
-ok 154 - to_semver(1.0.0-0.3.7) should return incoming text
-ok 155 - to_semver(1.0.0-x.7.z.92) should return incoming text
-ok 156 - to_semver(1.0.0-alpha+001) should return incoming text
-ok 157 - to_semver(1.0.0+20130313144700) should return incoming text
-ok 158 - to_semver(1.0.0-beta+exp.sha.5114f85) should return incoming text
-ok 159 - "1.2.0 beta 4" is not a valid semver
-ok 160 - "1.2.2-" is not a valid semver
-ok 161 - "1.2.3b#5" is not a valid semver
-ok 162 - "v1.2.2" is not a valid semver
-ok 163 - "1.4b.0" is not a valid semver
-ok 164 - "1v.2.2v" is not a valid semver
-ok 165 - "1.2.4b.5" is not a valid semver
-ok 166 - "1.2.3.4" is not a valid semver
-ok 167 - "1.2.3 4" is not a valid semver
-ok 168 - "1.2000000000000000.3.4" is not a valid semver
-ok 169 - max(semver) should work
-ok 170 - min(semver) should work
-ok 171 - ORDER BY semver USING < should work
-ok 172 - ORDER BY semver USING > should work
-ok 173 - construct to text
-ok 174 - construct from text
-ok 175 - construct from bare number
-ok 176 - construct from numeric
-ok 177 - construct from bare integer
-ok 178 - construct from integer
-ok 179 - construct from bigint
-ok 180 - construct from smallint
-ok 181 - construct from decimal
-ok 182 - construct from real
-ok 183 - construct from double
-ok 184 - construct from float
-ok 185 - cast to text
-ok 186 - cast from text
-ok 187 - Cast from bare integer
-ok 188 - Cast from bare number
-ok 189 - Cast from numeric
-ok 190 - Cast from integer
-ok 191 - Cast from bigint
-ok 192 - Cast from smallint
-ok 193 - Cast from decimal
-ok 194 - Cast from decimal
-ok 195 - Cast from real
-ok 196 - Cast from double precision
-ok 197 - Cast from float
-ok 198 - Should correctly cast "1.0.0-beta" to text
-ok 199 - Should correctly cast "1.0.0-beta1" to text
-ok 200 - Should correctly cast "1.0.0-alpha" to text
-ok 201 - Should correctly cast "1.0.0-alph" to text
-ok 202 - Should correctly cast "1.0.0-food" to text
-ok 203 - Should correctly cast "1.0.0-f111" to text
-ok 204 - Should correctly cast "1.0.0-f111asbcdasdfasdfasdfasdfasdfasdffasdfadsf" to text
-ok 205 - "1.0.0+1" is a valid 2.0.0 semver
-ok 206 - "1.0.0-1+1" is a valid 2.0.0 semver
-ok 207 - "1.0.0-1.1+1" is a valid 2.0.0 semver
-ok 208 - "1.0.0-1.1.1.1.1.1.1.1.1.1.1+1.1.1.1.1.1.1.1" is a valid 2.0.0 semver
-ok 209 - "1.0.0-1.2" is a valid 2.0.0 semver
-ok 210 - "1.0.0-1.0.2" is a valid 2.0.0 semver
-ok 211 - "1.0.0-alpha" is a valid 2.0.0 semver
-ok 212 - "1.0.0-alpha.1" is a valid 2.0.0 semver
-ok 213 - "1.0.0-0.3.7" is a valid 2.0.0 semver
-ok 214 - "1.0.0-x.7.z.92" is a valid 2.0.0 semver
-ok 215 - "0.2.13+1583426134.07de632" is a valid 2.0.0 semver
-ok 216 - "1.0.0-a.." is not a valid 2.0.0 semver
-ok 217 - "1.0.0-a.1." is not a valid 2.0.0 semver
-ok 218 - "1.0.0+1_1" is not a valid 2.0.0 semver
-ok 219 - "1.0.0-1...." is not a valid 2.0.0 semver
-ok 220 - "1.0.0-1_2" is not a valid 2.0.0 semver
-ok 221 - "1.0.0-1.02" is not a valid 2.0.0 semver
-ok 222 - ORDER BY semver (2.0.0) USING < should work
-ok 223 - ORDER BY semver (2.0.0) USING > should work
-ok 224 - semver(1.0.0-1+1, 1.0.0-1+5) should = 0
-ok 225 - v1.0.0-1+1 should = v1.0.0-1+5
-ok 226 - v1.0.0-1+1 should be <= v1.0.0-1+5
-ok 227 - v1.0.0-1+1 should be >= v1.0.0-1+5
-ok 228 - semver(1.0.0-1.1+1, 1.0.0-1.1+5) should = 0
-ok 229 - v1.0.0-1.1+1 should = v1.0.0-1.1+5
-ok 230 - v1.0.0-1.1+1 should be <= v1.0.0-1.1+5
-ok 231 - v1.0.0-1.1+1 should be >= v1.0.0-1.1+5
-ok 232 - Should correctly represent "0.5.0-release1" as "0.5.0-release1"
-ok 233 - Should correctly represent "0.5.0release1" as "0.5.0-release1"
-ok 234 - Should correctly represent "0.5-release1" as "0.5.0-release1"
-ok 235 - Should correctly represent "0.5release1" as "0.5.0-release1"
-ok 236 - Should correctly represent "0.5-1" as "0.5.0-1"
-ok 237 - Should correctly represent "1.2.3-1.02" as "1.2.3-1.2"
-ok 238 - Function is_semver() should exist
-ok 239 - Function is_semver(text) should exist
-ok 240 - Function is_semver() should return boolean
-ok 241 - is_semver(1.2.2) should return true
-ok 242 - is_semver(0.2.2) should return true
-ok 243 - is_semver(0.0.0) should return true
-ok 244 - is_semver(0.1.999) should return true
-ok 245 - is_semver(9999.9999999.823823) should return true
-ok 246 - is_semver(1.0.0-beta1) should return true
-ok 247 - is_semver(1.0.0-beta2) should return true
-ok 248 - is_semver(1.0.0) should return true
-ok 249 - is_semver(1.0.0-1) should return true
-ok 250 - is_semver(1.0.0-alpha+d34dm34t) should return true
-ok 251 - is_semver(1.0.0+d34dm34t) should return true
-ok 252 - is_semver(20110204.0.0) should return true
-ok 253 - is_semver(1.2) should return false
-ok 254 - is_semver(1.2.02) should return false
-ok 255 - is_semver(1.2.2-) should return false
-ok 256 - is_semver(1.2.3b#5) should return false
-ok 257 - is_semver(03.3.3) should return false
-ok 258 - is_semver(v1.2.2) should return false
-ok 259 - is_semver(1.3b) should return false
-ok 260 - is_semver(1.4b.0) should return false
-ok 261 - is_semver(1v) should return false
-ok 262 - is_semver(1v.2.2v) should return false
-ok 263 - is_semver(1.2.4b.5) should return false
-ok 264 - is_semver(2016.5.18-MYW-600) should return true
-ok 265 - is_semver(1010.5.0+2016-05-27-1832) should return true
-ok 266 - is_semver(0.2.13+1583426134.07de632) should return true
-ok 267 - "2.3.0+80" is a valid semver
-ok 268 - to_semver(2.3.0+80) should return 2.3.0+80
-ok 269 - Should correctly cast "2.3.0+80" to text
-ok 270 - "2.3.0+80" > "2.3.0+110" (NOT!)
-ok 271 - "2.3.0+80" > "2.3.0-alpha+110"
-ok 272 - ORDER BY semver USING < should work (section 11)
-ok 273 - ORDER BY semver USING > should work (section 11)
-ok 274 - "1.0.0" = "1.0.0+535"
-ok 275 - "1.0.0" < "1.0.0+535" (NOT!)
-ok 276 - "1.0.0" > "1.0.0+535" (NOT!)
-ok 277 - Function get_semver_major() should exist
-ok 278 - semver
-ok 279 - Function get_semver_major() should return integer
-ok 280 - major version check
-ok 281 - Function get_semver_minor() should exist
-ok 282 - semver
-ok 283 - Function get_semver_minor() should return integer
-ok 284 - minor version check
-ok 285 - Function get_semver_patch() should exist
-ok 286 - semver
-ok 287 - Function get_semver_patch() should return integer
-ok 288 - patch version check
-ok 289 - Function get_semver_prerelease() should exist
-ok 290 - semver
-ok 291 - Function get_semver_prerelease() should return text
-ok 292 - prerelease label check
-ok 293 - prerelease label check. must return prerelease only
-ok 294 - prerelease label check. must return empty string
-ok 295 - 1.0.0 should be in range [1.0.0, 2.0.0]
-ok 296 - 1.0.0 should not be in range [1.0.1, 2.0.0]
-ok 297 - 2.0.0 should not be in range [1.0.1, 2.0.0)
-ok 298 - 1.9999.9999 should be in range [1.0.1, 2.0.0)
-ok 299 - 1000.0.0 should be in range [1.0.0,)
-ok 300 - Should be able to work with arrays of semverranges
-ok 301 - Should properly format a 32 character semver
-ok 302 - Should properly format a 33 character semver
-ok 303 - Should propery format a prerelease with a hyphen
+ok 16 - "1.0.0+010" is a valid semver
+ok 17 - "1.0.0+alpha.010" is a valid semver
+ok 18 - "1.0.0-0AEF" is a valid semver
+ok 19 - "1.2" is not a valid semver
+ok 20 - "1.2.02" is not a valid semver
+ok 21 - "1.2.2-" is not a valid semver
+ok 22 - "1.2.3b#5" is not a valid semver
+ok 23 - "03.3.3" is not a valid semver
+ok 24 - "v1.2.2" is not a valid semver
+ok 25 - "1.3b" is not a valid semver
+ok 26 - "1.4b.0" is not a valid semver
+ok 27 - "1v" is not a valid semver
+ok 28 - "1v.2.2v" is not a valid semver
+ok 29 - "1.2.4b.5" is not a valid semver
+ok 30 - "1.0.0-alpha.010" is not a valid semver
+ok 31 - "1.0.0-02799" is not a valid semver
+ok 32 - semver(1.2.2, 1.2.2) should = 0
+ok 33 - v1.2.2 should = v1.2.2
+ok 34 - v1.2.2 should be <= v1.2.2
+ok 35 - v1.2.2 should be >= v1.2.2
+ok 36 - semver(1.2.23, 1.2.23) should = 0
+ok 37 - v1.2.23 should = v1.2.23
+ok 38 - v1.2.23 should be <= v1.2.23
+ok 39 - v1.2.23 should be >= v1.2.23
+ok 40 - semver(0.0.0, 0.0.0) should = 0
+ok 41 - v0.0.0 should = v0.0.0
+ok 42 - v0.0.0 should be <= v0.0.0
+ok 43 - v0.0.0 should be >= v0.0.0
+ok 44 - semver(999.888.7777, 999.888.7777) should = 0
+ok 45 - v999.888.7777 should = v999.888.7777
+ok 46 - v999.888.7777 should be <= v999.888.7777
+ok 47 - v999.888.7777 should be >= v999.888.7777
+ok 48 - semver(0.1.2-beta3, 0.1.2-beta3) should = 0
+ok 49 - v0.1.2-beta3 should = v0.1.2-beta3
+ok 50 - v0.1.2-beta3 should be <= v0.1.2-beta3
+ok 51 - v0.1.2-beta3 should be >= v0.1.2-beta3
+ok 52 - semver(1.0.0-rc-1, 1.0.0-RC-1) should = 0
+ok 53 - v1.0.0-rc-1 should = v1.0.0-RC-1
+ok 54 - v1.0.0-rc-1 should be <= v1.0.0-RC-1
+ok 55 - v1.0.0-rc-1 should be >= v1.0.0-RC-1
+ok 56 - semver(1.2.2, 1.2.3) should <> 0
+ok 57 - v1.2.2 should not equal v1.2.3
+ok 58 - semver(0.0.1, 1.0.0) should <> 0
+ok 59 - v0.0.1 should not equal v1.0.0
+ok 60 - semver(1.0.1, 1.1.0) should <> 0
+ok 61 - v1.0.1 should not equal v1.1.0
+ok 62 - semver(1.1.1, 1.1.0) should <> 0
+ok 63 - v1.1.1 should not equal v1.1.0
+ok 64 - semver(1.2.3-b, 1.2.3) should <> 0
+ok 65 - v1.2.3-b should not equal v1.2.3
+ok 66 - semver(1.2.3, 1.2.3-b) should <> 0
+ok 67 - v1.2.3 should not equal v1.2.3-b
+ok 68 - semver(1.2.3-a, 1.2.3-b) should <> 0
+ok 69 - v1.2.3-a should not equal v1.2.3-b
+ok 70 - semver(1.2.3-aaaaaaa1, 1.2.3-aaaaaaa2) should <> 0
+ok 71 - v1.2.3-aaaaaaa1 should not equal v1.2.3-aaaaaaa2
+ok 72 - semver(1.2.3-1.2.3, 1.2.3-1.2.3.4) should <> 0
+ok 73 - v1.2.3-1.2.3 should not equal v1.2.3-1.2.3.4
+ok 74 - semver(2.2.2, 1.1.1) should > 0
+ok 75 - semver(1.1.1, 2.2.2) should < 0
+ok 76 - v2.2.2 should be > v1.1.1
+ok 77 - v2.2.2 should be >= v1.1.1
+ok 78 - v1.1.1 should be < v2.2.2
+ok 79 - v1.1.1 should be <= v2.2.2
+ok 80 - semver(2.2.2, 2.1.1) should > 0
+ok 81 - semver(2.1.1, 2.2.2) should < 0
+ok 82 - v2.2.2 should be > v2.1.1
+ok 83 - v2.2.2 should be >= v2.1.1
+ok 84 - v2.1.1 should be < v2.2.2
+ok 85 - v2.1.1 should be <= v2.2.2
+ok 86 - semver(2.2.2, 2.2.1) should > 0
+ok 87 - semver(2.2.1, 2.2.2) should < 0
+ok 88 - v2.2.2 should be > v2.2.1
+ok 89 - v2.2.2 should be >= v2.2.1
+ok 90 - v2.2.1 should be < v2.2.2
+ok 91 - v2.2.1 should be <= v2.2.2
+ok 92 - semver(2.2.2-b, 2.2.1) should > 0
+ok 93 - semver(2.2.1, 2.2.2-b) should < 0
+ok 94 - v2.2.2-b should be > v2.2.1
+ok 95 - v2.2.2-b should be >= v2.2.1
+ok 96 - v2.2.1 should be < v2.2.2-b
+ok 97 - v2.2.1 should be <= v2.2.2-b
+ok 98 - semver(2.2.2, 2.2.2-b) should > 0
+ok 99 - semver(2.2.2-b, 2.2.2) should < 0
+ok 100 - v2.2.2 should be > v2.2.2-b
+ok 101 - v2.2.2 should be >= v2.2.2-b
+ok 102 - v2.2.2-b should be < v2.2.2
+ok 103 - v2.2.2-b should be <= v2.2.2
+ok 104 - semver(2.2.2-c, 2.2.2-b) should > 0
+ok 105 - semver(2.2.2-b, 2.2.2-c) should < 0
+ok 106 - v2.2.2-c should be > v2.2.2-b
+ok 107 - v2.2.2-c should be >= v2.2.2-b
+ok 108 - v2.2.2-b should be < v2.2.2-c
+ok 109 - v2.2.2-b should be <= v2.2.2-c
+ok 110 - semver(2.2.2-rc-2, 2.2.2-RC-1) should > 0
+ok 111 - semver(2.2.2-RC-1, 2.2.2-rc-2) should < 0
+ok 112 - v2.2.2-rc-2 should be > v2.2.2-RC-1
+ok 113 - v2.2.2-rc-2 should be >= v2.2.2-RC-1
+ok 114 - v2.2.2-RC-1 should be < v2.2.2-rc-2
+ok 115 - v2.2.2-RC-1 should be <= v2.2.2-rc-2
+ok 116 - semver(0.9.10, 0.9.9) should > 0
+ok 117 - semver(0.9.9, 0.9.10) should < 0
+ok 118 - v0.9.10 should be > v0.9.9
+ok 119 - v0.9.10 should be >= v0.9.9
+ok 120 - v0.9.9 should be < v0.9.10
+ok 121 - v0.9.9 should be <= v0.9.10
+ok 122 - semver(1.0.1-1.2.3, 1.0.1-0.9.9.9) should > 0
+ok 123 - semver(1.0.1-0.9.9.9, 1.0.1-1.2.3) should < 0
+ok 124 - v1.0.1-1.2.3 should be > v1.0.1-0.9.9.9
+ok 125 - v1.0.1-1.2.3 should be >= v1.0.1-0.9.9.9
+ok 126 - v1.0.1-0.9.9.9 should be < v1.0.1-1.2.3
+ok 127 - v1.0.1-0.9.9.9 should be <= v1.0.1-1.2.3
+ok 128 - Function to_semver() should exist
+ok 129 - Function to_semver(text) should exist
+ok 130 - Function to_semver() should return semver
+ok 131 - to_semver(1.2.2) should return 1.2.2
+ok 132 - to_semver(01.2.2) should return 1.2.2
+ok 133 - to_semver(1.02.2) should return 1.2.2
+ok 134 - to_semver(1.2.02) should return 1.2.2
+ok 135 - to_semver(1.2.02b) should return 1.2.2-b
+ok 136 - to_semver(1.2.02beta-3  ) should return 1.2.2-beta-3
+ok 137 - to_semver(1.02.02rc1) should return 1.2.2-rc1
+ok 138 - to_semver(1.0) should return 1.0.0
+ok 139 - to_semver(1) should return 1.0.0
+ok 140 - to_semver(.0.02) should return 0.0.2
+ok 141 - to_semver(1..02) should return 1.0.2
+ok 142 - to_semver(1..) should return 1.0.0
+ok 143 - to_semver(1.1) should return 1.1.0
+ok 144 - to_semver(1.2.b1) should return 1.2.0-b1
+ok 145 - to_semver(9.0beta4) should return 9.0.0-beta4
+ok 146 - to_semver(9b) should return 9.0.0-b
+ok 147 - to_semver(rc1) should return 0.0.0-rc1
+ok 148 - to_semver() should return 0.0.0
+ok 149 - to_semver(..2) should return 0.0.2
+ok 150 - to_semver(1.2.3 a) should return 1.2.3-a
+ok 151 - to_semver(..2 b) should return 0.0.2-b
+ok 152 - to_semver(  012.2.2) should return 12.2.2
+ok 153 - to_semver(20110204) should return 20110204.0.0
+ok 154 - to_semver(1.0.0-alpha) should return incoming text
+ok 155 - to_semver(1.0.0-alpha.1) should return incoming text
+ok 156 - to_semver(1.0.0-0.3.7) should return incoming text
+ok 157 - to_semver(1.0.0-x.7.z.92) should return incoming text
+ok 158 - to_semver(1.0.0-alpha+001) should return incoming text
+ok 159 - to_semver(1.0.0+20130313144700) should return incoming text
+ok 160 - to_semver(1.0.0-beta+exp.sha.5114f85) should return incoming text
+ok 161 - "1.2.0 beta 4" is not a valid semver
+ok 162 - "1.2.2-" is not a valid semver
+ok 163 - "1.2.3b#5" is not a valid semver
+ok 164 - "v1.2.2" is not a valid semver
+ok 165 - "1.4b.0" is not a valid semver
+ok 166 - "1v.2.2v" is not a valid semver
+ok 167 - "1.2.4b.5" is not a valid semver
+ok 168 - "1.2.3.4" is not a valid semver
+ok 169 - "1.2.3 4" is not a valid semver
+ok 170 - "1.2000000000000000.3.4" is not a valid semver
+ok 171 - max(semver) should work
+ok 172 - min(semver) should work
+ok 173 - ORDER BY semver USING < should work
+ok 174 - ORDER BY semver USING > should work
+ok 175 - construct to text
+ok 176 - construct from text
+ok 177 - construct from bare number
+ok 178 - construct from numeric
+ok 179 - construct from bare integer
+ok 180 - construct from integer
+ok 181 - construct from bigint
+ok 182 - construct from smallint
+ok 183 - construct from decimal
+ok 184 - construct from real
+ok 185 - construct from double
+ok 186 - construct from float
+ok 187 - cast to text
+ok 188 - cast from text
+ok 189 - Cast from bare integer
+ok 190 - Cast from bare number
+ok 191 - Cast from numeric
+ok 192 - Cast from integer
+ok 193 - Cast from bigint
+ok 194 - Cast from smallint
+ok 195 - Cast from decimal
+ok 196 - Cast from decimal
+ok 197 - Cast from real
+ok 198 - Cast from double precision
+ok 199 - Cast from float
+ok 200 - Should correctly cast "1.0.0-beta" to text
+ok 201 - Should correctly cast "1.0.0-beta1" to text
+ok 202 - Should correctly cast "1.0.0-alpha" to text
+ok 203 - Should correctly cast "1.0.0-alph" to text
+ok 204 - Should correctly cast "1.0.0-food" to text
+ok 205 - Should correctly cast "1.0.0-f111" to text
+ok 206 - Should correctly cast "1.0.0-f111asbcdasdfasdfasdfasdfasdfasdffasdfadsf" to text
+ok 207 - "1.0.0+1" is a valid 2.0.0 semver
+ok 208 - "1.0.0-1+1" is a valid 2.0.0 semver
+ok 209 - "1.0.0-1.1+1" is a valid 2.0.0 semver
+ok 210 - "1.0.0-1.1.1.1.1.1.1.1.1.1.1+1.1.1.1.1.1.1.1" is a valid 2.0.0 semver
+ok 211 - "1.0.0-1.2" is a valid 2.0.0 semver
+ok 212 - "1.0.0-1.0.2" is a valid 2.0.0 semver
+ok 213 - "1.0.0-alpha" is a valid 2.0.0 semver
+ok 214 - "1.0.0-alpha.1" is a valid 2.0.0 semver
+ok 215 - "1.0.0-0.3.7" is a valid 2.0.0 semver
+ok 216 - "1.0.0-x.7.z.92" is a valid 2.0.0 semver
+ok 217 - "0.2.13+1583426134.07de632" is a valid 2.0.0 semver
+ok 218 - "1.0.0-a.." is not a valid 2.0.0 semver
+ok 219 - "1.0.0-a.1." is not a valid 2.0.0 semver
+ok 220 - "1.0.0+1_1" is not a valid 2.0.0 semver
+ok 221 - "1.0.0-1...." is not a valid 2.0.0 semver
+ok 222 - "1.0.0-1_2" is not a valid 2.0.0 semver
+ok 223 - "1.0.0-1.02" is not a valid 2.0.0 semver
+ok 224 - ORDER BY semver (2.0.0) USING < should work
+ok 225 - ORDER BY semver (2.0.0) USING > should work
+ok 226 - semver(1.0.0-1+1, 1.0.0-1+5) should = 0
+ok 227 - v1.0.0-1+1 should = v1.0.0-1+5
+ok 228 - v1.0.0-1+1 should be <= v1.0.0-1+5
+ok 229 - v1.0.0-1+1 should be >= v1.0.0-1+5
+ok 230 - semver(1.0.0-1.1+1, 1.0.0-1.1+5) should = 0
+ok 231 - v1.0.0-1.1+1 should = v1.0.0-1.1+5
+ok 232 - v1.0.0-1.1+1 should be <= v1.0.0-1.1+5
+ok 233 - v1.0.0-1.1+1 should be >= v1.0.0-1.1+5
+ok 234 - Should correctly represent "0.5.0-release1" as "0.5.0-release1"
+ok 235 - Should correctly represent "0.5.0release1" as "0.5.0-release1"
+ok 236 - Should correctly represent "0.5-release1" as "0.5.0-release1"
+ok 237 - Should correctly represent "0.5release1" as "0.5.0-release1"
+ok 238 - Should correctly represent "0.5-1" as "0.5.0-1"
+ok 239 - Should correctly represent "1.2.3-1.02" as "1.2.3-1.2"
+ok 240 - Function is_semver() should exist
+ok 241 - Function is_semver(text) should exist
+ok 242 - Function is_semver() should return boolean
+ok 243 - is_semver(1.2.2) should return true
+ok 244 - is_semver(0.2.2) should return true
+ok 245 - is_semver(0.0.0) should return true
+ok 246 - is_semver(0.1.999) should return true
+ok 247 - is_semver(9999.9999999.823823) should return true
+ok 248 - is_semver(1.0.0-beta1) should return true
+ok 249 - is_semver(1.0.0-beta2) should return true
+ok 250 - is_semver(1.0.0) should return true
+ok 251 - is_semver(1.0.0-1) should return true
+ok 252 - is_semver(1.0.0-alpha+d34dm34t) should return true
+ok 253 - is_semver(1.0.0+d34dm34t) should return true
+ok 254 - is_semver(20110204.0.0) should return true
+ok 255 - is_semver(1.2) should return false
+ok 256 - is_semver(1.2.02) should return false
+ok 257 - is_semver(1.2.2-) should return false
+ok 258 - is_semver(1.2.3b#5) should return false
+ok 259 - is_semver(03.3.3) should return false
+ok 260 - is_semver(v1.2.2) should return false
+ok 261 - is_semver(1.3b) should return false
+ok 262 - is_semver(1.4b.0) should return false
+ok 263 - is_semver(1v) should return false
+ok 264 - is_semver(1v.2.2v) should return false
+ok 265 - is_semver(1.2.4b.5) should return false
+ok 266 - is_semver(2016.5.18-MYW-600) should return true
+ok 267 - is_semver(1010.5.0+2016-05-27-1832) should return true
+ok 268 - is_semver(0.2.13+1583426134.07de632) should return true
+ok 269 - "2.3.0+80" is a valid semver
+ok 270 - to_semver(2.3.0+80) should return 2.3.0+80
+ok 271 - Should correctly cast "2.3.0+80" to text
+ok 272 - "2.3.0+80" > "2.3.0+110" (NOT!)
+ok 273 - "2.3.0+80" > "2.3.0-alpha+110"
+ok 274 - ORDER BY semver USING < should work (section 11)
+ok 275 - ORDER BY semver USING > should work (section 11)
+ok 276 - "1.0.0" = "1.0.0+535"
+ok 277 - "1.0.0" < "1.0.0+535" (NOT!)
+ok 278 - "1.0.0" > "1.0.0+535" (NOT!)
+ok 279 - Function get_semver_major() should exist
+ok 280 - semver
+ok 281 - Function get_semver_major() should return integer
+ok 282 - major version check
+ok 283 - Function get_semver_minor() should exist
+ok 284 - semver
+ok 285 - Function get_semver_minor() should return integer
+ok 286 - minor version check
+ok 287 - Function get_semver_patch() should exist
+ok 288 - semver
+ok 289 - Function get_semver_patch() should return integer
+ok 290 - patch version check
+ok 291 - Function get_semver_prerelease() should exist
+ok 292 - semver
+ok 293 - Function get_semver_prerelease() should return text
+ok 294 - prerelease label check
+ok 295 - prerelease label check. must return prerelease only
+ok 296 - prerelease label check. must return empty string
+ok 297 - 1.0.0 should be in range [1.0.0, 2.0.0]
+ok 298 - 1.0.0 should not be in range [1.0.1, 2.0.0]
+ok 299 - 2.0.0 should not be in range [1.0.1, 2.0.0)
+ok 300 - 1.9999.9999 should be in range [1.0.1, 2.0.0)
+ok 301 - 1000.0.0 should be in range [1.0.0,)
+ok 302 - Should be able to work with arrays of semverranges
+ok 303 - Should properly format a 32 character semver
+ok 304 - Should properly format a 33 character semver
+ok 305 - Should propery format a prerelease with a hyphen

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..299
+1..303
 ok 1 - Type semver should exist
 ok 2 - semvers should be NULLable
 ok 3 - "1.2.2" is a valid semver
@@ -14,288 +14,292 @@ ok 11 - "1.0.0-1" is a valid semver
 ok 12 - "1.0.0-alpha+d34dm34t" is a valid semver
 ok 13 - "1.0.0+d34dm34t" is a valid semver
 ok 14 - "20110204.0.0" is a valid semver
-ok 15 - "1.2" is not a valid semver
-ok 16 - "1.2.02" is not a valid semver
-ok 17 - "1.2.2-" is not a valid semver
-ok 18 - "1.2.3b#5" is not a valid semver
-ok 19 - "03.3.3" is not a valid semver
-ok 20 - "v1.2.2" is not a valid semver
-ok 21 - "1.3b" is not a valid semver
-ok 22 - "1.4b.0" is not a valid semver
-ok 23 - "1v" is not a valid semver
-ok 24 - "1v.2.2v" is not a valid semver
-ok 25 - "1.2.4b.5" is not a valid semver
-ok 26 - semver(1.2.2, 1.2.2) should = 0
-ok 27 - v1.2.2 should = v1.2.2
-ok 28 - v1.2.2 should be <= v1.2.2
-ok 29 - v1.2.2 should be >= v1.2.2
-ok 30 - semver(1.2.23, 1.2.23) should = 0
-ok 31 - v1.2.23 should = v1.2.23
-ok 32 - v1.2.23 should be <= v1.2.23
-ok 33 - v1.2.23 should be >= v1.2.23
-ok 34 - semver(0.0.0, 0.0.0) should = 0
-ok 35 - v0.0.0 should = v0.0.0
-ok 36 - v0.0.0 should be <= v0.0.0
-ok 37 - v0.0.0 should be >= v0.0.0
-ok 38 - semver(999.888.7777, 999.888.7777) should = 0
-ok 39 - v999.888.7777 should = v999.888.7777
-ok 40 - v999.888.7777 should be <= v999.888.7777
-ok 41 - v999.888.7777 should be >= v999.888.7777
-ok 42 - semver(0.1.2-beta3, 0.1.2-beta3) should = 0
-ok 43 - v0.1.2-beta3 should = v0.1.2-beta3
-ok 44 - v0.1.2-beta3 should be <= v0.1.2-beta3
-ok 45 - v0.1.2-beta3 should be >= v0.1.2-beta3
-ok 46 - semver(1.0.0-rc-1, 1.0.0-RC-1) should = 0
-ok 47 - v1.0.0-rc-1 should = v1.0.0-RC-1
-ok 48 - v1.0.0-rc-1 should be <= v1.0.0-RC-1
-ok 49 - v1.0.0-rc-1 should be >= v1.0.0-RC-1
-ok 50 - semver(1.2.2, 1.2.3) should <> 0
-ok 51 - v1.2.2 should not equal v1.2.3
-ok 52 - semver(0.0.1, 1.0.0) should <> 0
-ok 53 - v0.0.1 should not equal v1.0.0
-ok 54 - semver(1.0.1, 1.1.0) should <> 0
-ok 55 - v1.0.1 should not equal v1.1.0
-ok 56 - semver(1.1.1, 1.1.0) should <> 0
-ok 57 - v1.1.1 should not equal v1.1.0
-ok 58 - semver(1.2.3-b, 1.2.3) should <> 0
-ok 59 - v1.2.3-b should not equal v1.2.3
-ok 60 - semver(1.2.3, 1.2.3-b) should <> 0
-ok 61 - v1.2.3 should not equal v1.2.3-b
-ok 62 - semver(1.2.3-a, 1.2.3-b) should <> 0
-ok 63 - v1.2.3-a should not equal v1.2.3-b
-ok 64 - semver(1.2.3-aaaaaaa1, 1.2.3-aaaaaaa2) should <> 0
-ok 65 - v1.2.3-aaaaaaa1 should not equal v1.2.3-aaaaaaa2
-ok 66 - semver(1.2.3-1.2.3, 1.2.3-1.2.3.4) should <> 0
-ok 67 - v1.2.3-1.2.3 should not equal v1.2.3-1.2.3.4
-ok 68 - semver(2.2.2, 1.1.1) should > 0
-ok 69 - semver(1.1.1, 2.2.2) should < 0
-ok 70 - v2.2.2 should be > v1.1.1
-ok 71 - v2.2.2 should be >= v1.1.1
-ok 72 - v1.1.1 should be < v2.2.2
-ok 73 - v1.1.1 should be <= v2.2.2
-ok 74 - semver(2.2.2, 2.1.1) should > 0
-ok 75 - semver(2.1.1, 2.2.2) should < 0
-ok 76 - v2.2.2 should be > v2.1.1
-ok 77 - v2.2.2 should be >= v2.1.1
-ok 78 - v2.1.1 should be < v2.2.2
-ok 79 - v2.1.1 should be <= v2.2.2
-ok 80 - semver(2.2.2, 2.2.1) should > 0
-ok 81 - semver(2.2.1, 2.2.2) should < 0
-ok 82 - v2.2.2 should be > v2.2.1
-ok 83 - v2.2.2 should be >= v2.2.1
-ok 84 - v2.2.1 should be < v2.2.2
-ok 85 - v2.2.1 should be <= v2.2.2
-ok 86 - semver(2.2.2-b, 2.2.1) should > 0
-ok 87 - semver(2.2.1, 2.2.2-b) should < 0
-ok 88 - v2.2.2-b should be > v2.2.1
-ok 89 - v2.2.2-b should be >= v2.2.1
-ok 90 - v2.2.1 should be < v2.2.2-b
-ok 91 - v2.2.1 should be <= v2.2.2-b
-ok 92 - semver(2.2.2, 2.2.2-b) should > 0
-ok 93 - semver(2.2.2-b, 2.2.2) should < 0
-ok 94 - v2.2.2 should be > v2.2.2-b
-ok 95 - v2.2.2 should be >= v2.2.2-b
-ok 96 - v2.2.2-b should be < v2.2.2
-ok 97 - v2.2.2-b should be <= v2.2.2
-ok 98 - semver(2.2.2-c, 2.2.2-b) should > 0
-ok 99 - semver(2.2.2-b, 2.2.2-c) should < 0
-ok 100 - v2.2.2-c should be > v2.2.2-b
-ok 101 - v2.2.2-c should be >= v2.2.2-b
-ok 102 - v2.2.2-b should be < v2.2.2-c
-ok 103 - v2.2.2-b should be <= v2.2.2-c
-ok 104 - semver(2.2.2-rc-2, 2.2.2-RC-1) should > 0
-ok 105 - semver(2.2.2-RC-1, 2.2.2-rc-2) should < 0
-ok 106 - v2.2.2-rc-2 should be > v2.2.2-RC-1
-ok 107 - v2.2.2-rc-2 should be >= v2.2.2-RC-1
-ok 108 - v2.2.2-RC-1 should be < v2.2.2-rc-2
-ok 109 - v2.2.2-RC-1 should be <= v2.2.2-rc-2
-ok 110 - semver(0.9.10, 0.9.9) should > 0
-ok 111 - semver(0.9.9, 0.9.10) should < 0
-ok 112 - v0.9.10 should be > v0.9.9
-ok 113 - v0.9.10 should be >= v0.9.9
-ok 114 - v0.9.9 should be < v0.9.10
-ok 115 - v0.9.9 should be <= v0.9.10
-ok 116 - semver(1.0.1-1.2.3, 1.0.1-0.9.9.9) should > 0
-ok 117 - semver(1.0.1-0.9.9.9, 1.0.1-1.2.3) should < 0
-ok 118 - v1.0.1-1.2.3 should be > v1.0.1-0.9.9.9
-ok 119 - v1.0.1-1.2.3 should be >= v1.0.1-0.9.9.9
-ok 120 - v1.0.1-0.9.9.9 should be < v1.0.1-1.2.3
-ok 121 - v1.0.1-0.9.9.9 should be <= v1.0.1-1.2.3
-ok 122 - Function to_semver() should exist
-ok 123 - Function to_semver(text) should exist
-ok 124 - Function to_semver() should return semver
-ok 125 - to_semver(1.2.2) should return 1.2.2
-ok 126 - to_semver(01.2.2) should return 1.2.2
-ok 127 - to_semver(1.02.2) should return 1.2.2
-ok 128 - to_semver(1.2.02) should return 1.2.2
-ok 129 - to_semver(1.2.02b) should return 1.2.2-b
-ok 130 - to_semver(1.2.02beta-3  ) should return 1.2.2-beta-3
-ok 131 - to_semver(1.02.02rc1) should return 1.2.2-rc1
-ok 132 - to_semver(1.0) should return 1.0.0
-ok 133 - to_semver(1) should return 1.0.0
-ok 134 - to_semver(.0.02) should return 0.0.2
-ok 135 - to_semver(1..02) should return 1.0.2
-ok 136 - to_semver(1..) should return 1.0.0
-ok 137 - to_semver(1.1) should return 1.1.0
-ok 138 - to_semver(1.2.b1) should return 1.2.0-b1
-ok 139 - to_semver(9.0beta4) should return 9.0.0-beta4
-ok 140 - to_semver(9b) should return 9.0.0-b
-ok 141 - to_semver(rc1) should return 0.0.0-rc1
-ok 142 - to_semver() should return 0.0.0
-ok 143 - to_semver(..2) should return 0.0.2
-ok 144 - to_semver(1.2.3 a) should return 1.2.3-a
-ok 145 - to_semver(..2 b) should return 0.0.2-b
-ok 146 - to_semver(  012.2.2) should return 12.2.2
-ok 147 - to_semver(20110204) should return 20110204.0.0
-ok 148 - to_semver(1.0.0-alpha) should return incoming text
-ok 149 - to_semver(1.0.0-alpha.1) should return incoming text
-ok 150 - to_semver(1.0.0-0.3.7) should return incoming text
-ok 151 - to_semver(1.0.0-x.7.z.92) should return incoming text
-ok 152 - to_semver(1.0.0-alpha+001) should return incoming text
-ok 153 - to_semver(1.0.0+20130313144700) should return incoming text
-ok 154 - to_semver(1.0.0-beta+exp.sha.5114f85) should return incoming text
-ok 155 - "1.2.0 beta 4" is not a valid semver
-ok 156 - "1.2.2-" is not a valid semver
-ok 157 - "1.2.3b#5" is not a valid semver
-ok 158 - "v1.2.2" is not a valid semver
-ok 159 - "1.4b.0" is not a valid semver
-ok 160 - "1v.2.2v" is not a valid semver
-ok 161 - "1.2.4b.5" is not a valid semver
-ok 162 - "1.2.3.4" is not a valid semver
-ok 163 - "1.2.3 4" is not a valid semver
-ok 164 - "1.2000000000000000.3.4" is not a valid semver
-ok 165 - max(semver) should work
-ok 166 - min(semver) should work
-ok 167 - ORDER BY semver USING < should work
-ok 168 - ORDER BY semver USING > should work
-ok 169 - construct to text
-ok 170 - construct from text
-ok 171 - construct from bare number
-ok 172 - construct from numeric
-ok 173 - construct from bare integer
-ok 174 - construct from integer
-ok 175 - construct from bigint
-ok 176 - construct from smallint
-ok 177 - construct from decimal
-ok 178 - construct from real
-ok 179 - construct from double
-ok 180 - construct from float
-ok 181 - cast to text
-ok 182 - cast from text
-ok 183 - Cast from bare integer
-ok 184 - Cast from bare number
-ok 185 - Cast from numeric
-ok 186 - Cast from integer
-ok 187 - Cast from bigint
-ok 188 - Cast from smallint
-ok 189 - Cast from decimal
-ok 190 - Cast from decimal
-ok 191 - Cast from real
-ok 192 - Cast from double precision
-ok 193 - Cast from float
-ok 194 - Should correctly cast "1.0.0-beta" to text
-ok 195 - Should correctly cast "1.0.0-beta1" to text
-ok 196 - Should correctly cast "1.0.0-alpha" to text
-ok 197 - Should correctly cast "1.0.0-alph" to text
-ok 198 - Should correctly cast "1.0.0-food" to text
-ok 199 - Should correctly cast "1.0.0-f111" to text
-ok 200 - Should correctly cast "1.0.0-f111asbcdasdfasdfasdfasdfasdfasdffasdfadsf" to text
-ok 201 - "1.0.0+1" is a valid 2.0.0 semver
-ok 202 - "1.0.0-1+1" is a valid 2.0.0 semver
-ok 203 - "1.0.0-1.1+1" is a valid 2.0.0 semver
-ok 204 - "1.0.0-1.1.1.1.1.1.1.1.1.1.1+1.1.1.1.1.1.1.1" is a valid 2.0.0 semver
-ok 205 - "1.0.0-1.2" is a valid 2.0.0 semver
-ok 206 - "1.0.0-1.0.2" is a valid 2.0.0 semver
-ok 207 - "1.0.0-alpha" is a valid 2.0.0 semver
-ok 208 - "1.0.0-alpha.1" is a valid 2.0.0 semver
-ok 209 - "1.0.0-0.3.7" is a valid 2.0.0 semver
-ok 210 - "1.0.0-x.7.z.92" is a valid 2.0.0 semver
-ok 211 - "0.2.13+1583426134.07de632" is a valid 2.0.0 semver
-ok 212 - "1.0.0-a.." is not a valid 2.0.0 semver
-ok 213 - "1.0.0-a.1." is not a valid 2.0.0 semver
-ok 214 - "1.0.0+1_1" is not a valid 2.0.0 semver
-ok 215 - "1.0.0-1...." is not a valid 2.0.0 semver
-ok 216 - "1.0.0-1_2" is not a valid 2.0.0 semver
-ok 217 - "1.0.0-1.02" is not a valid 2.0.0 semver
-ok 218 - ORDER BY semver (2.0.0) USING < should work
-ok 219 - ORDER BY semver (2.0.0) USING > should work
-ok 220 - semver(1.0.0-1+1, 1.0.0-1+5) should = 0
-ok 221 - v1.0.0-1+1 should = v1.0.0-1+5
-ok 222 - v1.0.0-1+1 should be <= v1.0.0-1+5
-ok 223 - v1.0.0-1+1 should be >= v1.0.0-1+5
-ok 224 - semver(1.0.0-1.1+1, 1.0.0-1.1+5) should = 0
-ok 225 - v1.0.0-1.1+1 should = v1.0.0-1.1+5
-ok 226 - v1.0.0-1.1+1 should be <= v1.0.0-1.1+5
-ok 227 - v1.0.0-1.1+1 should be >= v1.0.0-1.1+5
-ok 228 - Should correctly represent "0.5.0-release1" as "0.5.0-release1"
-ok 229 - Should correctly represent "0.5.0release1" as "0.5.0-release1"
-ok 230 - Should correctly represent "0.5-release1" as "0.5.0-release1"
-ok 231 - Should correctly represent "0.5release1" as "0.5.0-release1"
-ok 232 - Should correctly represent "0.5-1" as "0.5.0-1"
-ok 233 - Should correctly represent "1.2.3-1.02" as "1.2.3-1.2"
-ok 234 - Function is_semver() should exist
-ok 235 - Function is_semver(text) should exist
-ok 236 - Function is_semver() should return boolean
-ok 237 - is_semver(1.2.2) should return true
-ok 238 - is_semver(0.2.2) should return true
-ok 239 - is_semver(0.0.0) should return true
-ok 240 - is_semver(0.1.999) should return true
-ok 241 - is_semver(9999.9999999.823823) should return true
-ok 242 - is_semver(1.0.0-beta1) should return true
-ok 243 - is_semver(1.0.0-beta2) should return true
-ok 244 - is_semver(1.0.0) should return true
-ok 245 - is_semver(1.0.0-1) should return true
-ok 246 - is_semver(1.0.0-alpha+d34dm34t) should return true
-ok 247 - is_semver(1.0.0+d34dm34t) should return true
-ok 248 - is_semver(20110204.0.0) should return true
-ok 249 - is_semver(1.2) should return false
-ok 250 - is_semver(1.2.02) should return false
-ok 251 - is_semver(1.2.2-) should return false
-ok 252 - is_semver(1.2.3b#5) should return false
-ok 253 - is_semver(03.3.3) should return false
-ok 254 - is_semver(v1.2.2) should return false
-ok 255 - is_semver(1.3b) should return false
-ok 256 - is_semver(1.4b.0) should return false
-ok 257 - is_semver(1v) should return false
-ok 258 - is_semver(1v.2.2v) should return false
-ok 259 - is_semver(1.2.4b.5) should return false
-ok 260 - is_semver(2016.5.18-MYW-600) should return true
-ok 261 - is_semver(1010.5.0+2016-05-27-1832) should return true
-ok 262 - is_semver(0.2.13+1583426134.07de632) should return true
-ok 263 - "2.3.0+80" is a valid semver
-ok 264 - to_semver(2.3.0+80) should return 2.3.0+80
-ok 265 - Should correctly cast "2.3.0+80" to text
-ok 266 - "2.3.0+80" > "2.3.0+110" (NOT!)
-ok 267 - "2.3.0+80" > "2.3.0-alpha+110"
-ok 268 - ORDER BY semver USING < should work (section 11)
-ok 269 - ORDER BY semver USING > should work (section 11)
-ok 270 - "1.0.0" = "1.0.0+535"
-ok 271 - "1.0.0" < "1.0.0+535" (NOT!)
-ok 272 - "1.0.0" > "1.0.0+535" (NOT!)
-ok 273 - Function get_semver_major() should exist
-ok 274 - semver
-ok 275 - Function get_semver_major() should return integer
-ok 276 - major version check
-ok 277 - Function get_semver_minor() should exist
+ok 15 - "1.0.0-alpha.0a" is a valid semver
+ok 16 - "1.0.0-0AEF" is a valid semver
+ok 17 - "1.2" is not a valid semver
+ok 18 - "1.2.02" is not a valid semver
+ok 19 - "1.2.2-" is not a valid semver
+ok 20 - "1.2.3b#5" is not a valid semver
+ok 21 - "03.3.3" is not a valid semver
+ok 22 - "v1.2.2" is not a valid semver
+ok 23 - "1.3b" is not a valid semver
+ok 24 - "1.4b.0" is not a valid semver
+ok 25 - "1v" is not a valid semver
+ok 26 - "1v.2.2v" is not a valid semver
+ok 27 - "1.2.4b.5" is not a valid semver
+ok 28 - "1.0.0-alpha.010" is not a valid semver
+ok 29 - "1.0.0-02799" is not a valid semver
+ok 30 - semver(1.2.2, 1.2.2) should = 0
+ok 31 - v1.2.2 should = v1.2.2
+ok 32 - v1.2.2 should be <= v1.2.2
+ok 33 - v1.2.2 should be >= v1.2.2
+ok 34 - semver(1.2.23, 1.2.23) should = 0
+ok 35 - v1.2.23 should = v1.2.23
+ok 36 - v1.2.23 should be <= v1.2.23
+ok 37 - v1.2.23 should be >= v1.2.23
+ok 38 - semver(0.0.0, 0.0.0) should = 0
+ok 39 - v0.0.0 should = v0.0.0
+ok 40 - v0.0.0 should be <= v0.0.0
+ok 41 - v0.0.0 should be >= v0.0.0
+ok 42 - semver(999.888.7777, 999.888.7777) should = 0
+ok 43 - v999.888.7777 should = v999.888.7777
+ok 44 - v999.888.7777 should be <= v999.888.7777
+ok 45 - v999.888.7777 should be >= v999.888.7777
+ok 46 - semver(0.1.2-beta3, 0.1.2-beta3) should = 0
+ok 47 - v0.1.2-beta3 should = v0.1.2-beta3
+ok 48 - v0.1.2-beta3 should be <= v0.1.2-beta3
+ok 49 - v0.1.2-beta3 should be >= v0.1.2-beta3
+ok 50 - semver(1.0.0-rc-1, 1.0.0-RC-1) should = 0
+ok 51 - v1.0.0-rc-1 should = v1.0.0-RC-1
+ok 52 - v1.0.0-rc-1 should be <= v1.0.0-RC-1
+ok 53 - v1.0.0-rc-1 should be >= v1.0.0-RC-1
+ok 54 - semver(1.2.2, 1.2.3) should <> 0
+ok 55 - v1.2.2 should not equal v1.2.3
+ok 56 - semver(0.0.1, 1.0.0) should <> 0
+ok 57 - v0.0.1 should not equal v1.0.0
+ok 58 - semver(1.0.1, 1.1.0) should <> 0
+ok 59 - v1.0.1 should not equal v1.1.0
+ok 60 - semver(1.1.1, 1.1.0) should <> 0
+ok 61 - v1.1.1 should not equal v1.1.0
+ok 62 - semver(1.2.3-b, 1.2.3) should <> 0
+ok 63 - v1.2.3-b should not equal v1.2.3
+ok 64 - semver(1.2.3, 1.2.3-b) should <> 0
+ok 65 - v1.2.3 should not equal v1.2.3-b
+ok 66 - semver(1.2.3-a, 1.2.3-b) should <> 0
+ok 67 - v1.2.3-a should not equal v1.2.3-b
+ok 68 - semver(1.2.3-aaaaaaa1, 1.2.3-aaaaaaa2) should <> 0
+ok 69 - v1.2.3-aaaaaaa1 should not equal v1.2.3-aaaaaaa2
+ok 70 - semver(1.2.3-1.2.3, 1.2.3-1.2.3.4) should <> 0
+ok 71 - v1.2.3-1.2.3 should not equal v1.2.3-1.2.3.4
+ok 72 - semver(2.2.2, 1.1.1) should > 0
+ok 73 - semver(1.1.1, 2.2.2) should < 0
+ok 74 - v2.2.2 should be > v1.1.1
+ok 75 - v2.2.2 should be >= v1.1.1
+ok 76 - v1.1.1 should be < v2.2.2
+ok 77 - v1.1.1 should be <= v2.2.2
+ok 78 - semver(2.2.2, 2.1.1) should > 0
+ok 79 - semver(2.1.1, 2.2.2) should < 0
+ok 80 - v2.2.2 should be > v2.1.1
+ok 81 - v2.2.2 should be >= v2.1.1
+ok 82 - v2.1.1 should be < v2.2.2
+ok 83 - v2.1.1 should be <= v2.2.2
+ok 84 - semver(2.2.2, 2.2.1) should > 0
+ok 85 - semver(2.2.1, 2.2.2) should < 0
+ok 86 - v2.2.2 should be > v2.2.1
+ok 87 - v2.2.2 should be >= v2.2.1
+ok 88 - v2.2.1 should be < v2.2.2
+ok 89 - v2.2.1 should be <= v2.2.2
+ok 90 - semver(2.2.2-b, 2.2.1) should > 0
+ok 91 - semver(2.2.1, 2.2.2-b) should < 0
+ok 92 - v2.2.2-b should be > v2.2.1
+ok 93 - v2.2.2-b should be >= v2.2.1
+ok 94 - v2.2.1 should be < v2.2.2-b
+ok 95 - v2.2.1 should be <= v2.2.2-b
+ok 96 - semver(2.2.2, 2.2.2-b) should > 0
+ok 97 - semver(2.2.2-b, 2.2.2) should < 0
+ok 98 - v2.2.2 should be > v2.2.2-b
+ok 99 - v2.2.2 should be >= v2.2.2-b
+ok 100 - v2.2.2-b should be < v2.2.2
+ok 101 - v2.2.2-b should be <= v2.2.2
+ok 102 - semver(2.2.2-c, 2.2.2-b) should > 0
+ok 103 - semver(2.2.2-b, 2.2.2-c) should < 0
+ok 104 - v2.2.2-c should be > v2.2.2-b
+ok 105 - v2.2.2-c should be >= v2.2.2-b
+ok 106 - v2.2.2-b should be < v2.2.2-c
+ok 107 - v2.2.2-b should be <= v2.2.2-c
+ok 108 - semver(2.2.2-rc-2, 2.2.2-RC-1) should > 0
+ok 109 - semver(2.2.2-RC-1, 2.2.2-rc-2) should < 0
+ok 110 - v2.2.2-rc-2 should be > v2.2.2-RC-1
+ok 111 - v2.2.2-rc-2 should be >= v2.2.2-RC-1
+ok 112 - v2.2.2-RC-1 should be < v2.2.2-rc-2
+ok 113 - v2.2.2-RC-1 should be <= v2.2.2-rc-2
+ok 114 - semver(0.9.10, 0.9.9) should > 0
+ok 115 - semver(0.9.9, 0.9.10) should < 0
+ok 116 - v0.9.10 should be > v0.9.9
+ok 117 - v0.9.10 should be >= v0.9.9
+ok 118 - v0.9.9 should be < v0.9.10
+ok 119 - v0.9.9 should be <= v0.9.10
+ok 120 - semver(1.0.1-1.2.3, 1.0.1-0.9.9.9) should > 0
+ok 121 - semver(1.0.1-0.9.9.9, 1.0.1-1.2.3) should < 0
+ok 122 - v1.0.1-1.2.3 should be > v1.0.1-0.9.9.9
+ok 123 - v1.0.1-1.2.3 should be >= v1.0.1-0.9.9.9
+ok 124 - v1.0.1-0.9.9.9 should be < v1.0.1-1.2.3
+ok 125 - v1.0.1-0.9.9.9 should be <= v1.0.1-1.2.3
+ok 126 - Function to_semver() should exist
+ok 127 - Function to_semver(text) should exist
+ok 128 - Function to_semver() should return semver
+ok 129 - to_semver(1.2.2) should return 1.2.2
+ok 130 - to_semver(01.2.2) should return 1.2.2
+ok 131 - to_semver(1.02.2) should return 1.2.2
+ok 132 - to_semver(1.2.02) should return 1.2.2
+ok 133 - to_semver(1.2.02b) should return 1.2.2-b
+ok 134 - to_semver(1.2.02beta-3  ) should return 1.2.2-beta-3
+ok 135 - to_semver(1.02.02rc1) should return 1.2.2-rc1
+ok 136 - to_semver(1.0) should return 1.0.0
+ok 137 - to_semver(1) should return 1.0.0
+ok 138 - to_semver(.0.02) should return 0.0.2
+ok 139 - to_semver(1..02) should return 1.0.2
+ok 140 - to_semver(1..) should return 1.0.0
+ok 141 - to_semver(1.1) should return 1.1.0
+ok 142 - to_semver(1.2.b1) should return 1.2.0-b1
+ok 143 - to_semver(9.0beta4) should return 9.0.0-beta4
+ok 144 - to_semver(9b) should return 9.0.0-b
+ok 145 - to_semver(rc1) should return 0.0.0-rc1
+ok 146 - to_semver() should return 0.0.0
+ok 147 - to_semver(..2) should return 0.0.2
+ok 148 - to_semver(1.2.3 a) should return 1.2.3-a
+ok 149 - to_semver(..2 b) should return 0.0.2-b
+ok 150 - to_semver(  012.2.2) should return 12.2.2
+ok 151 - to_semver(20110204) should return 20110204.0.0
+ok 152 - to_semver(1.0.0-alpha) should return incoming text
+ok 153 - to_semver(1.0.0-alpha.1) should return incoming text
+ok 154 - to_semver(1.0.0-0.3.7) should return incoming text
+ok 155 - to_semver(1.0.0-x.7.z.92) should return incoming text
+ok 156 - to_semver(1.0.0-alpha+001) should return incoming text
+ok 157 - to_semver(1.0.0+20130313144700) should return incoming text
+ok 158 - to_semver(1.0.0-beta+exp.sha.5114f85) should return incoming text
+ok 159 - "1.2.0 beta 4" is not a valid semver
+ok 160 - "1.2.2-" is not a valid semver
+ok 161 - "1.2.3b#5" is not a valid semver
+ok 162 - "v1.2.2" is not a valid semver
+ok 163 - "1.4b.0" is not a valid semver
+ok 164 - "1v.2.2v" is not a valid semver
+ok 165 - "1.2.4b.5" is not a valid semver
+ok 166 - "1.2.3.4" is not a valid semver
+ok 167 - "1.2.3 4" is not a valid semver
+ok 168 - "1.2000000000000000.3.4" is not a valid semver
+ok 169 - max(semver) should work
+ok 170 - min(semver) should work
+ok 171 - ORDER BY semver USING < should work
+ok 172 - ORDER BY semver USING > should work
+ok 173 - construct to text
+ok 174 - construct from text
+ok 175 - construct from bare number
+ok 176 - construct from numeric
+ok 177 - construct from bare integer
+ok 178 - construct from integer
+ok 179 - construct from bigint
+ok 180 - construct from smallint
+ok 181 - construct from decimal
+ok 182 - construct from real
+ok 183 - construct from double
+ok 184 - construct from float
+ok 185 - cast to text
+ok 186 - cast from text
+ok 187 - Cast from bare integer
+ok 188 - Cast from bare number
+ok 189 - Cast from numeric
+ok 190 - Cast from integer
+ok 191 - Cast from bigint
+ok 192 - Cast from smallint
+ok 193 - Cast from decimal
+ok 194 - Cast from decimal
+ok 195 - Cast from real
+ok 196 - Cast from double precision
+ok 197 - Cast from float
+ok 198 - Should correctly cast "1.0.0-beta" to text
+ok 199 - Should correctly cast "1.0.0-beta1" to text
+ok 200 - Should correctly cast "1.0.0-alpha" to text
+ok 201 - Should correctly cast "1.0.0-alph" to text
+ok 202 - Should correctly cast "1.0.0-food" to text
+ok 203 - Should correctly cast "1.0.0-f111" to text
+ok 204 - Should correctly cast "1.0.0-f111asbcdasdfasdfasdfasdfasdfasdffasdfadsf" to text
+ok 205 - "1.0.0+1" is a valid 2.0.0 semver
+ok 206 - "1.0.0-1+1" is a valid 2.0.0 semver
+ok 207 - "1.0.0-1.1+1" is a valid 2.0.0 semver
+ok 208 - "1.0.0-1.1.1.1.1.1.1.1.1.1.1+1.1.1.1.1.1.1.1" is a valid 2.0.0 semver
+ok 209 - "1.0.0-1.2" is a valid 2.0.0 semver
+ok 210 - "1.0.0-1.0.2" is a valid 2.0.0 semver
+ok 211 - "1.0.0-alpha" is a valid 2.0.0 semver
+ok 212 - "1.0.0-alpha.1" is a valid 2.0.0 semver
+ok 213 - "1.0.0-0.3.7" is a valid 2.0.0 semver
+ok 214 - "1.0.0-x.7.z.92" is a valid 2.0.0 semver
+ok 215 - "0.2.13+1583426134.07de632" is a valid 2.0.0 semver
+ok 216 - "1.0.0-a.." is not a valid 2.0.0 semver
+ok 217 - "1.0.0-a.1." is not a valid 2.0.0 semver
+ok 218 - "1.0.0+1_1" is not a valid 2.0.0 semver
+ok 219 - "1.0.0-1...." is not a valid 2.0.0 semver
+ok 220 - "1.0.0-1_2" is not a valid 2.0.0 semver
+ok 221 - "1.0.0-1.02" is not a valid 2.0.0 semver
+ok 222 - ORDER BY semver (2.0.0) USING < should work
+ok 223 - ORDER BY semver (2.0.0) USING > should work
+ok 224 - semver(1.0.0-1+1, 1.0.0-1+5) should = 0
+ok 225 - v1.0.0-1+1 should = v1.0.0-1+5
+ok 226 - v1.0.0-1+1 should be <= v1.0.0-1+5
+ok 227 - v1.0.0-1+1 should be >= v1.0.0-1+5
+ok 228 - semver(1.0.0-1.1+1, 1.0.0-1.1+5) should = 0
+ok 229 - v1.0.0-1.1+1 should = v1.0.0-1.1+5
+ok 230 - v1.0.0-1.1+1 should be <= v1.0.0-1.1+5
+ok 231 - v1.0.0-1.1+1 should be >= v1.0.0-1.1+5
+ok 232 - Should correctly represent "0.5.0-release1" as "0.5.0-release1"
+ok 233 - Should correctly represent "0.5.0release1" as "0.5.0-release1"
+ok 234 - Should correctly represent "0.5-release1" as "0.5.0-release1"
+ok 235 - Should correctly represent "0.5release1" as "0.5.0-release1"
+ok 236 - Should correctly represent "0.5-1" as "0.5.0-1"
+ok 237 - Should correctly represent "1.2.3-1.02" as "1.2.3-1.2"
+ok 238 - Function is_semver() should exist
+ok 239 - Function is_semver(text) should exist
+ok 240 - Function is_semver() should return boolean
+ok 241 - is_semver(1.2.2) should return true
+ok 242 - is_semver(0.2.2) should return true
+ok 243 - is_semver(0.0.0) should return true
+ok 244 - is_semver(0.1.999) should return true
+ok 245 - is_semver(9999.9999999.823823) should return true
+ok 246 - is_semver(1.0.0-beta1) should return true
+ok 247 - is_semver(1.0.0-beta2) should return true
+ok 248 - is_semver(1.0.0) should return true
+ok 249 - is_semver(1.0.0-1) should return true
+ok 250 - is_semver(1.0.0-alpha+d34dm34t) should return true
+ok 251 - is_semver(1.0.0+d34dm34t) should return true
+ok 252 - is_semver(20110204.0.0) should return true
+ok 253 - is_semver(1.2) should return false
+ok 254 - is_semver(1.2.02) should return false
+ok 255 - is_semver(1.2.2-) should return false
+ok 256 - is_semver(1.2.3b#5) should return false
+ok 257 - is_semver(03.3.3) should return false
+ok 258 - is_semver(v1.2.2) should return false
+ok 259 - is_semver(1.3b) should return false
+ok 260 - is_semver(1.4b.0) should return false
+ok 261 - is_semver(1v) should return false
+ok 262 - is_semver(1v.2.2v) should return false
+ok 263 - is_semver(1.2.4b.5) should return false
+ok 264 - is_semver(2016.5.18-MYW-600) should return true
+ok 265 - is_semver(1010.5.0+2016-05-27-1832) should return true
+ok 266 - is_semver(0.2.13+1583426134.07de632) should return true
+ok 267 - "2.3.0+80" is a valid semver
+ok 268 - to_semver(2.3.0+80) should return 2.3.0+80
+ok 269 - Should correctly cast "2.3.0+80" to text
+ok 270 - "2.3.0+80" > "2.3.0+110" (NOT!)
+ok 271 - "2.3.0+80" > "2.3.0-alpha+110"
+ok 272 - ORDER BY semver USING < should work (section 11)
+ok 273 - ORDER BY semver USING > should work (section 11)
+ok 274 - "1.0.0" = "1.0.0+535"
+ok 275 - "1.0.0" < "1.0.0+535" (NOT!)
+ok 276 - "1.0.0" > "1.0.0+535" (NOT!)
+ok 277 - Function get_semver_major() should exist
 ok 278 - semver
-ok 279 - Function get_semver_minor() should return integer
-ok 280 - minor version check
-ok 281 - Function get_semver_patch() should exist
+ok 279 - Function get_semver_major() should return integer
+ok 280 - major version check
+ok 281 - Function get_semver_minor() should exist
 ok 282 - semver
-ok 283 - Function get_semver_patch() should return integer
-ok 284 - patch version check
-ok 285 - Function get_semver_prerelease() should exist
+ok 283 - Function get_semver_minor() should return integer
+ok 284 - minor version check
+ok 285 - Function get_semver_patch() should exist
 ok 286 - semver
-ok 287 - Function get_semver_prerelease() should return text
-ok 288 - prerelease label check
-ok 289 - prerelease label check. must return prerelease only
-ok 290 - prerelease label check. must return empty string
-ok 291 - 1.0.0 should be in range [1.0.0, 2.0.0]
-ok 292 - 1.0.0 should not be in range [1.0.1, 2.0.0]
-ok 293 - 2.0.0 should not be in range [1.0.1, 2.0.0)
-ok 294 - 1.9999.9999 should be in range [1.0.1, 2.0.0)
-ok 295 - 1000.0.0 should be in range [1.0.0,)
-ok 296 - Should be able to work with arrays of semverranges
-ok 297 - Should properly format a 32 character semver
-ok 298 - Should properly format a 33 character semver
-ok 299 - Should propery format a prerelease with a hyphen
+ok 287 - Function get_semver_patch() should return integer
+ok 288 - patch version check
+ok 289 - Function get_semver_prerelease() should exist
+ok 290 - semver
+ok 291 - Function get_semver_prerelease() should return text
+ok 292 - prerelease label check
+ok 293 - prerelease label check. must return prerelease only
+ok 294 - prerelease label check. must return empty string
+ok 295 - 1.0.0 should be in range [1.0.0, 2.0.0]
+ok 296 - 1.0.0 should not be in range [1.0.1, 2.0.0]
+ok 297 - 2.0.0 should not be in range [1.0.1, 2.0.0)
+ok 298 - 1.9999.9999 should be in range [1.0.1, 2.0.0)
+ok 299 - 1000.0.0 should be in range [1.0.0,)
+ok 300 - Should be able to work with arrays of semverranges
+ok 301 - Should properly format a 32 character semver
+ok 302 - Should properly format a 33 character semver
+ok 303 - Should propery format a prerelease with a hyphen

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -4,7 +4,7 @@ BEGIN;
 \i test/pgtap-core.sql
 \i sql/semver.sql
 
-SELECT plan(299);
+SELECT plan(303);
 --SELECT * FROM no_plan();
 
 SELECT has_type('semver');
@@ -25,7 +25,9 @@ SELECT lives_ok(
     '1.0.0-1',
     '1.0.0-alpha+d34dm34t',
     '1.0.0+d34dm34t',
-    '20110204.0.0'
+    '20110204.0.0',
+    '1.0.0-alpha.0a',
+    '1.0.0-0AEF'
 ]) AS v;
 
 SELECT throws_ok(
@@ -33,17 +35,19 @@ SELECT throws_ok(
     NULL,
     '"' || v || '" is not a valid semver'
 )  FROM unnest(ARRAY[
-   '1.2',
-   '1.2.02',
-   '1.2.2-',
-   '1.2.3b#5',
-   '03.3.3',
-   'v1.2.2',
-   '1.3b',
-   '1.4b.0',
-   '1v',
-   '1v.2.2v',
-   '1.2.4b.5'
+    '1.2',
+    '1.2.02',
+    '1.2.2-',
+    '1.2.3b#5',
+    '03.3.3',
+    'v1.2.2',
+    '1.3b',
+    '1.4b.0',
+    '1v',
+    '1v.2.2v',
+    '1.2.4b.5',
+    '1.0.0-alpha.010',
+    '1.0.0-02799'
 ]) AS v;
 
 -- Test =, <=, and >=.

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -4,7 +4,7 @@ BEGIN;
 \i test/pgtap-core.sql
 \i sql/semver.sql
 
-SELECT plan(303);
+SELECT plan(305);
 --SELECT * FROM no_plan();
 
 SELECT has_type('semver');
@@ -27,6 +27,8 @@ SELECT lives_ok(
     '1.0.0+d34dm34t',
     '20110204.0.0',
     '1.0.0-alpha.0a',
+    '1.0.0+010',
+    '1.0.0+alpha.010',
     '1.0.0-0AEF'
 ]) AS v;
 


### PR DESCRIPTION
In response to discussion on #45, properly prevent leading `0`s in prerelease parts only when there are no alphanumeric characters. Also fix an issue where it would ignore the first leading `0` in a prerelease no matter what else was in the part.