### PR TITLE
Add support for binary wire format

### DIFF
--- a/sql/semver.sql
+++ b/sql/semver.sql
@@ -34,6 +34,16 @@ CREATE OR REPLACE FUNCTION semver_out(semver)
 	AS 'semver'
 	LANGUAGE C STRICT IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION semver_recv(internal)
+    RETURNS semver
+    AS 'semver'
+    LANGUAGE C STRICT IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION semver_send(semver)
+    RETURNS bytea
+    AS 'semver'
+    LANGUAGE C STRICT IMMUTABLE;
+
 --
 --  The type itself.
 --
@@ -41,6 +51,8 @@ CREATE OR REPLACE FUNCTION semver_out(semver)
 CREATE TYPE semver (
 	INPUT = semver_in,
 	OUTPUT = semver_out,
+	RECEIVE = semver_recv,
+	SEND = semver_send,
 	-- values of passedbyvalue and alignment are copied from the named type.
     STORAGE = plain,
 	INTERNALLENGTH = variable,


### PR DESCRIPTION
Implements #59.

> The most portable is probably to pack them into a char string, literally the ascii bytes that make up a server. Might also eventually end up as the internal representation, too (see extensive discussion in https://github.com/theory/pg-semver/issues/47).

That is what I have done with these two functions, I think. On the wire, it should pack the semver into a byte array consisting of its string bytes, and for receiving, it parses a string sent the same way.

I'm new to C (usually write Rust), so I'm not sure if I'm freeing everything I should do. I welcome feedback. I also got intimidated by the tests and didn't write any for this, though I have tested that it works myself with SQLx.