### PR TITLE
Revamp send/receive and test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        pg: [14, 13, 12, 11, 10, 9.6, 9.5, 9.4, 9.3, 9.2]
+        pg: [15, 14, 13, 12, 11, 10, 9.6, 9.5, 9.4, 9.3, 9.2]
     name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ regression.out
 /semver-*
 /latest-changes.md
 /src/*.bc
+/semver_binary_copy.bin
+/.vscode

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for PostgreSQL extension semver.
 
-0.31.3
+0.32.0
+      - Add support for binary input (receive) and output (send) functions.
+        Thanks to Anna Clemens for the pull request (#61)!
 
 0.31.2  2021-09-28T02:03:35Z
       - Add an overflow check and properly compare the max size of INT32

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2021 The pg-semver Maintainers: David E. Wheeler, Sam
+Copyright (c) 2010-2022 The pg-semver Maintainers: David E. Wheeler, Sam
 Vilain, Tom Davis, and Xavier Caron.
 
 This module is free software; you can redistribute it and/or modify it under

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "semver",
    "abstract": "A semantic version data type",
    "description": "A Postgres data type for the Semantic Version format with support for btree and hash indexing.",
-   "version": "0.31.2",
+   "version": "0.32.0",
    "maintainer": [
       "David E. Wheeler <david@justatheory.com>",
       "Sam Vilain <sam@vilain.net>",
@@ -15,7 +15,7 @@
          "abstract": "A semantic version data type",
          "file": "sql/semver.sql",
          "docfile": "doc/semver.mmd",
-         "version": "0.31.2"
+         "version": "0.32.0"
       }
    },
    "prereqs": {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-semver 0.31.2
+semver 0.32.0
 =============
 
 [![PGXN version](https://badge.fury.io/pg/semver.svg)](https://badge.fury.io/pg/semver)
@@ -78,7 +78,7 @@ for testing, PL/pgSQL.
 Copyright and License
 ---------------------
 
-Copyright (c) 2010-2021 The pg-semver Maintainers: David E. Wheeler, Sam
+Copyright (c) 2010-2022 The pg-semver Maintainers: David E. Wheeler, Sam
 Vilain, Tom Davis, and Xavier Caron.
 
 This module is free software; you can redistribute it and/or modify it under

--- a/doc/semver.mmd
+++ b/doc/semver.mmd
@@ -1,4 +1,4 @@
-semver 0.31.2
+semver 0.32.0
 =============
 
 Synopsis
@@ -342,7 +342,7 @@ Authors
 Copyright and License
 ---------------------
 
-Copyright (c) 2010-2021 The pg-semver Maintainers: David E. Wheeler, Sam
+Copyright (c) 2010-2022 The pg-semver Maintainers: David E. Wheeler, Sam
 Vilain, Tom Davis, and Xavier Caron.
 
 This module is free software; you can redistribute it and/or modify it under

--- a/semver.control
+++ b/semver.control
@@ -1,5 +1,5 @@
 # semver extension
 comment = 'Semantic version data type'
-default_version = '0.31.2'
+default_version = '0.32.0'
 module_pathname = '$libdir/semver'
 relocatable = true

--- a/sql/semver--0.31.2--0.32.0.sql
+++ b/sql/semver--0.31.2--0.32.0.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION semver_recv(internal)
+    RETURNS semver
+    AS 'semver'
+    LANGUAGE C STRICT IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION semver_send(semver)
+    RETURNS bytea
+    AS 'semver'
+    LANGUAGE C STRICT IMMUTABLE;
+
+ALTER TYPE semver SET
+	RECEIVE = semver_recv,
+	SEND = semver_send;

--- a/sql/semver.sql
+++ b/sql/semver.sql
@@ -34,6 +34,16 @@ CREATE OR REPLACE FUNCTION semver_out(semver)
 	AS 'semver'
 	LANGUAGE C STRICT IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION semver_recv(internal)
+    RETURNS semver
+    AS 'semver'
+    LANGUAGE C STRICT IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION semver_send(semver)
+    RETURNS bytea
+    AS 'semver'
+    LANGUAGE C STRICT IMMUTABLE;
+
 --
 --  The type itself.
 --
@@ -41,6 +51,8 @@ CREATE OR REPLACE FUNCTION semver_out(semver)
 CREATE TYPE semver (
 	INPUT = semver_in,
 	OUTPUT = semver_out,
+	RECEIVE = semver_recv,
+	SEND = semver_send,
 	-- values of passedbyvalue and alignment are copied from the named type.
     STORAGE = plain,
 	INTERNALLENGTH = variable,

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..312
+1..334
 ok 1 - Type semver should exist
 ok 2 - semvers should be NULLable
 ok 3 - "1.2.2" is a valid semver
@@ -312,3 +312,25 @@ ok 309 - Should properly format a 32 character semver
 ok 310 - Should properly format a 33 character semver
 ok 311 - Should propery format a prerelease with a hyphen
 ok 312 - Should get distinct values via hash aggregation
+ok 313 - Function semver_send() should exist
+ok 314 - Function semver_send(semver) should exist
+ok 315 - Function semver_send() should return bytea
+ok 316 - Function semver_recv() should exist
+ok 317 - Function semver_recv(internal) should exist
+ok 318 - Function semver_recv() should return semver
+ok 319 - semver_send('0.9.9-a1.1+1234')
+ok 320 - semver_send('0.9.9-a1.2.3')
+ok 321 - semver_send('0.9.9-a1.2')
+ok 322 - semver_send('0.9.9')
+ok 323 - semver_send('1.0.0+99')
+ok 324 - semver_send('1.0.0-1')
+ok 325 - semver_send('1.2.2')
+ok 326 - semver_send('9999.9999999.823823')
+ok 327 - semver_send('1.0.0-beta1')
+ok 328 - semver_send('1.0.0-1')
+ok 329 - semver_send('1.0.0-alpha+d34dm34t')
+ok 330 - semver_send('1.0.0+d34dm34t')
+ok 331 - semver_send('20110204.0.0')
+ok 332 - semver_send('1.0.0-0AEF')
+ok 333 - semver_send(NULL)
+ok 334 - Should have binary copied all of the semvers


### PR DESCRIPTION
Follow ltree's example by prepending a version and using the pg_msg functions. Add tests. A little hinky to use `\copy` to write to a file and then read it back in, but it is the only way I could figure out to test the receive function, which binary COPY FROM uses.

Increment to v0.32.0 and update the copyright date.

A million thanks to @ascclemens for making this happen!