### PR TITLE
Fix README documentation of the one-line make command install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ package management system such as RPM to install PostgreSQL, be sure that the
 to find it:
 
 ```sh
-env PG_CONFIG=/path/to/pg_config make && make installcheck && make install
+env PG_CONFIG=/path/to/pg_config make && make install && make installcheck
 ```
 
 If you encounter an error such as:


### PR DESCRIPTION
The one-liner in the README has the user run the `make installcheck` before doing the `make install`, which results in the tests failing. This MR fixes that so `make install` happens before `make installcheck`